### PR TITLE
Use writer instead of file for backup.

### DIFF
--- a/cmd/etcd-backup/backup.go
+++ b/cmd/etcd-backup/backup.go
@@ -56,7 +56,7 @@ func backup(cmd *cobra.Command, args []string) (err error) {
 
 	writer := os.Stdout
 	if len(args) > 0 && args[0] != "" {
-		writer, err = os.OpenFile(args[0], os.O_WRONLY|os.O_CREATE, 0666)
+		writer, err = os.Create(args[0])
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Update etcd backup tool to write backup data to stdout if output file is not provided.

Previously backup would require output file which is not very flexible. Now it accepts a generic `io.Writer` which makes it easier to use for things like collecting debug reports and easier to use from code.