### PR TITLE
preserve revisions

### DIFF
--- a/cmd/etcd-backup/root.go
+++ b/cmd/etcd-backup/root.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	etcdv2 "github.com/coreos/etcd/client"
-	etcdv3 "github.com/coreos/etcd/clientv3"
 	etcdconf "github.com/gravitational/coordinate/config"
 	"github.com/gravitational/trace"
 	"github.com/spf13/cobra"
+	etcdv2 "go.etcd.io/etcd/client"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 var (

--- a/lib/etcd/backup.go
+++ b/lib/etcd/backup.go
@@ -22,11 +22,11 @@ import (
 	"io"
 	"os"
 
-	etcdv2 "github.com/coreos/etcd/client"
-	etcdv3 "github.com/coreos/etcd/clientv3"
 	etcdconf "github.com/gravitational/coordinate/config"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	etcdv2 "go.etcd.io/etcd/client"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 // BackupConfig are the settings to use for running a backup of the etcd database

--- a/lib/etcd/common.go
+++ b/lib/etcd/common.go
@@ -89,5 +89,5 @@ type KeyValue struct {
 	Lease int64 `protobuf:"varint,6,opt,name=lease,proto3" json:"lease,omitempty"`
 	// TTL (not from etcd datastructure)
 	// This is the TTL of the key, which we look up during the backup, because etcd3 stores these separatly from the key
-	TTL int64 `json:ttl,omitempty`
+	TTL int64 `json:"ttl,omitempty"`
 }

--- a/lib/etcd/common.go
+++ b/lib/etcd/common.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"time"
 
-	etcdv2 "github.com/coreos/etcd/client"
-	etcdv3 "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/go-semver/semver"
 	etcdconf "github.com/gravitational/coordinate/config"
 	"github.com/gravitational/trace"
+	etcdv2 "go.etcd.io/etcd/client"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 func getClients(config etcdconf.Config) (etcdv2.KeysAPI, *etcdv3.Client, error) {

--- a/lib/etcd/restore.go
+++ b/lib/etcd/restore.go
@@ -89,7 +89,7 @@ func Restore(ctx context.Context, conf RestoreConfig) error {
 		return trace.Wrap(err)
 	}
 	if version.Version != FileVersion {
-		return trace.BadParameter("Unsupported backup version %v. ", version.Version)
+		return trace.BadParameter("Unsupported backup version %v.", version.Version)
 	}
 
 	for {
@@ -133,6 +133,7 @@ func OfflineRestore(ctx context.Context, conf RestoreConfig, dir string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer file.Close()
 
 	decoder := json.NewDecoder(file)
 
@@ -143,7 +144,7 @@ func OfflineRestore(ctx context.Context, conf RestoreConfig, dir string) error {
 		return trace.Wrap(err)
 	}
 	if version.Version != FileVersion {
-		return trace.BadParameter("Unsupported backup version %v. ", version.Version)
+		return trace.BadParameter("Unsupported backup version %v.", version.Version)
 	}
 
 	// Open the etcd database directly

--- a/lib/etcd/restore.go
+++ b/lib/etcd/restore.go
@@ -218,19 +218,28 @@ func restoreNodeV2(ctx context.Context, conf RestoreConfig, node *etcdv2.Node, k
 
 			return trace.Wrap(retry(ctx, func() error {
 				_, err := clientv3.KV.Put(ctx, node.Key, node.Value, etcdv3.WithLease(lease.ID))
-				return trace.Wrap(err).AddField("key", node.Key)
+				if err != nil {
+					return trace.Wrap(err).AddField("key", node.Key)
+				}
+				return nil
 			}))
 
 		}
 		return trace.Wrap(retry(ctx, func() error {
 			_, err := clientv3.KV.Put(ctx, node.Key, node.Value)
-			return trace.Wrap(err).AddField("key", node.Key)
+			if err != nil {
+				return trace.Wrap(err).AddField("key", node.Key)
+			}
+			return nil
 		}))
 
 	}
 	return trace.Wrap(retry(ctx, func() error {
 		_, err := keysv2.Set(ctx, node.Key, node.Value, &etcdv2.SetOptions{TTL: node.TTLDuration(), Dir: node.Dir})
-		return trace.Wrap(err).AddField("key", node.Key)
+		if err != nil {
+			return trace.Wrap(err).AddField("key", node.Key)
+		}
+		return nil
 	}))
 
 }
@@ -251,13 +260,19 @@ func restoreNodeV3(ctx context.Context, conf RestoreConfig, node *KeyValue, clie
 		}
 		return trace.Wrap(retry(ctx, func() error {
 			_, err := clientv3.KV.Put(ctx, string(node.Key), string(node.Value), etcdv3.WithLease(lease.ID))
-			return trace.Wrap(err).AddField("key", string(node.Key))
+			if err != nil {
+				return trace.Wrap(err).AddField("key", string(node.Key))
+			}
+			return nil
 		}))
 	}
 
 	return trace.Wrap(retry(ctx, func() error {
 		_, err := clientv3.KV.Put(ctx, string(node.Key), string(node.Value))
-		return trace.Wrap(err).AddField("key", string(node.Key))
+		if err != nil {
+			return trace.Wrap(err).AddField("key", string(node.Key))
+		}
+		return nil
 	}))
 
 }

--- a/lib/etcd/restore.go
+++ b/lib/etcd/restore.go
@@ -218,19 +218,19 @@ func restoreNodeV2(ctx context.Context, conf RestoreConfig, node *etcdv2.Node, k
 
 			return trace.Wrap(retry(ctx, func() error {
 				_, err := clientv3.KV.Put(ctx, node.Key, node.Value, etcdv3.WithLease(lease.ID))
-				return trace.Wrap(err)
+				return trace.Wrap(err).AddField("key", node.Key)
 			}))
 
 		}
 		return trace.Wrap(retry(ctx, func() error {
 			_, err := clientv3.KV.Put(ctx, node.Key, node.Value)
-			return trace.Wrap(err)
+			return trace.Wrap(err).AddField("key", node.Key)
 		}))
 
 	}
 	return trace.Wrap(retry(ctx, func() error {
 		_, err := keysv2.Set(ctx, node.Key, node.Value, &etcdv2.SetOptions{TTL: node.TTLDuration(), Dir: node.Dir})
-		return trace.Wrap(err)
+		return trace.Wrap(err).AddField("key", node.Key)
 	}))
 
 }
@@ -251,13 +251,13 @@ func restoreNodeV3(ctx context.Context, conf RestoreConfig, node *KeyValue, clie
 		}
 		return trace.Wrap(retry(ctx, func() error {
 			_, err := clientv3.KV.Put(ctx, string(node.Key), string(node.Value), etcdv3.WithLease(lease.ID))
-			return trace.Wrap(err)
+			return trace.Wrap(err).AddField("key", string(node.Key))
 		}))
 	}
 
 	return trace.Wrap(retry(ctx, func() error {
 		_, err := clientv3.KV.Put(ctx, string(node.Key), string(node.Value))
-		return trace.Wrap(err)
+		return trace.Wrap(err).AddField("key", string(node.Key))
 	}))
 
 }


### PR DESCRIPTION
This updates the backup/restore code to support an "offline" restore mode. This supports opening an etcd DB directly, and using etcd's internal API to write records to the kvstore snapshot. This allows us to write records with the correct revisions as of the backup. As such, anything watching the kvstore will be able to resume watches, as the revisioins will not change during the upgrade.

This also makes API based write more resilient by including retry logic, to avoid temporary etcd glitches during the restore.